### PR TITLE
Fix: typos, and readability improvements in HandbookforS1b2.md, Admissions.md

### DIFF
--- a/wiki/About.md
+++ b/wiki/About.md
@@ -20,4 +20,3 @@ The helpline is available from **9:00 AM to 5:30 PM** on working days. ~~Please 
 ## About Us
 We are a community of NIOS students from various platforms, dedicated to creating helpful wikis, guides, and how-tos for free!  
 T_T Thank you for all the support !
-

--- a/wiki/About.md
+++ b/wiki/About.md
@@ -19,4 +19,4 @@ The helpline is available from **9:00 AM to 5:30 PM** on working days. ~~Please 
 
 ## About Us
 We are a community of NIOS students from various platforms, dedicated to creating helpful wikis, guides, and how-tos for free!  
-T_T Thank you for all the support !
+T_T Thank you for all the support!

--- a/wiki/Admissions.md
+++ b/wiki/Admissions.md
@@ -1,87 +1,90 @@
 # Admission
 
-__Admissions are completely online from [sdmis.nios.ac.in](https://sdmis.nios.ac.in) only__ (For 12th (Sr.Sec), 10th (Sec), and obe)
+__Admissions are completely online from [sdmis.nios.ac.in](https://sdmis.nios.ac.in) only__ (For 12th (Sr. Sec), 10th (Sec), and OBE).
 
 # Secondary (10th Standard)
 
-This Course is equivalent to the Xth standard. However NIOS integrates 9th and 10th into one grade. The content of 9th and 10th present in it's books. Unlike other boards you may choose your subjects from the [table](https://www.nios.ac.in/departmentsunits/academic/senior-secondary-course-equivalent-to-class-xii.aspx) 
+This course is equivalent to the Xth standard. However, NIOS integrates 9th and 10th into one grade. The content of 9th and 10th is present in its books. Unlike other boards, you may choose your subjects from the [table](https://www.nios.ac.in/departmentsunits/academic/senior-secondary-course-equivalent-to-class-xii.aspx).  
 <img src="https://cdn.jsdelivr.net/gh/nios-students/docs@master/wiki/assets/Screenshot%202024-09-13%20190823.png" alt="Screenshot" width="400">
 
-**Exceptions** 
+**Exceptions**
 
-1. a) You are required to take __at least 1 language sebject__
+1. a) You are required to take __at least 1 language subject__.
 
-b) You __can take upto 2 language sebject(s)__ e.g. Hindi and English ***✔*** ~~Hindi,English and Arabic~~ ***X***
+   b) You __can take up to 2 language subject(s)__ e.g., Hindi and English ***✔*** ~~Hindi, English, and Arabic~~ ***X***.
 
-2. a) You are required to opt  __4 academic sebjects for "certification"__ (*not* including language sebjects)
- 
-> [!NOTE]
-> The reason why certification in qoutes because part/dual students don't get a certificate. They just pass specific sebjects that they need for there career e.g. For taking admission into the commercial pilot course one of the requirement is that the student has to study physics and mathematics in 12th so,they take register in part admission to fulfil the requirements **IF** you just passed 8th/9th i.e a fresher. You must click **NO** for part admission when registering/ Filing the admission form
+2. a) You are required to opt for __4 academic subjects for "certification"__ (*not* including language subjects).  
+   > [!NOTE]  
+   > The reason why "certification" is in quotes is because part/dual students don't get a certificate. They just pass specific subjects that they need for their career.  
+   > e.g., For taking admission into a commercial pilot course, one of the requirements is that the student has to study Physics and Mathematics in 12th. So, they register in part admission to fulfill the requirements.  
+   > **IF** you just passed 8th/9th (i.e., a fresher), you must click **NO** for part admission when registering/filling the admission form.
 
-b) You can add 2 __more subjects but the maximum count of subjects shouldn't go past seven i.e. no more than 7 sebjects__
+   b) You can add 2 __more subjects, but the maximum count of subjects shouldn't exceed seven (i.e., no more than 7 subjects)__.
 
-c) You can choose one vocational sebject.
+   c) You can choose one vocational subject.
 
-d) NIOS let's you choice any sebject however, you **MUST** chose your sebjects according to your future career/goals
+   d) NIOS lets you choose any subject; however, you **MUST** choose your subjects according to your future career/goals.
 
-e) You can choose one [vocational sebject](https://nios-students.pages.dev/wiki/FAQ'S#what-is-the-two-vocational-sebjects-role:~:text=10th%20Vocational%20Subjects)
+   e) Don't think that you can complete 12th in one year. __If you passed out of 10th, you are required to maintain a 1-year gap between passing 10th and completing 12th.__
 
 # Senior Secondary (12th Standard)
 
-This Course is equivalent to the 12th standard. However NIOS integrates 11th and 12th into one grade. The content of 11th and 12th present in it's books. Unlike other boards you may choose your subjects from the [table](https://www.nios.ac.in/departmentsunits/academic/senior-secondary-course-equivalent-to-class-xii.aspx) 
+This course is equivalent to the 12th standard. However, NIOS integrates 11th and 12th into one grade. The content of 11th and 12th is present in its books. Unlike other boards, you may choose your subjects from the [table](https://www.nios.ac.in/departmentsunits/academic/senior-secondary-course-equivalent-to-class-xii.aspx).  
 <img src="https://cdn.jsdelivr.net/gh/nios-students/docs@master/wiki/assets/Screenshot%202024-09-13%20190823.png" alt="Screenshot" width="400">
 
-**Exceptions** 
+**Exceptions**
 
-1. a) You are required to take __at least 1 language sebject__
+1. a) You are required to take __at least 1 language subject__.
 
-b) You __can take upto 2 language sebject(s)__ e.g. Hindi and English ***✔*** ~~Hindi,English and Arabic~~ ***X***
+   b) You __can take up to 2 language subject(s)__ e.g., Hindi and English ***✔*** ~~Hindi, English, and Arabic~~ ***X***.
 
-2. a) You are required to opt  __4 academic sebjects for "certification"__ (*not* including language sebjects) 
-> [!NOTE]
-> The reason why certification in qoutes because part/dual students don't get a certificate. They just pass specific sebjects that they need for there career e.g. For taking admission into the commercial pilot course one of the requirement is that the student has to study physics and mathematics in 12th so,they take register in part admission to fulfil the requirements **IF** you just passed 8th/9th i.e a fresher. You must click **NO** for part admission when registering/ Filing the admission form.
+2. a) You are required to opt for __4 academic subjects for "certification"__ (*not* including language subjects).  
+   > [!NOTE]  
+   > The reason why "certification" is in quotes is because part/dual students don't get a certificate. They just pass specific subjects that they need for their career.  
+   > e.g., For taking admission into a commercial pilot course, one of the requirements is that the student has to study Physics and Mathematics in 12th. So, they register in part admission to fulfill the requirements.  
+   > **IF** you just passed 8th/9th (i.e., a fresher), you must click **NO** for part admission when registering/filling the admission form.
 
-b) You can add 2 __more subjects but the maximum count of subjects shouldn't go past seven i.e. no more than 7 sebjects__
+   b) You can add 2 __more subjects, but the maximum count of subjects shouldn't exceed seven (i.e., no more than 7 subjects)__.
 
-c) NIOS let's you choice any sebject however, you **MUST** chose your sebjects according to your future career/goals
+   c) NIOS lets you choose any subject; however, you **MUST** choose your subjects according to your future career/goals.
 
-d) Don't think that you can complete 12th in one year __IF you passed out of 10th you are required to maintain 1 year gap between passing from 10th and Completing 12th__
+   d) Don't think that you can complete 12th in one year. __If you passed out of 10th, you are required to maintain a 1-year gap between passing 10th and completing 12th.__
 
-e) You can choose one [vocational sebject](https://nios-students.pages.dev/wiki/FAQ'S#what-is-the-two-vocational-sebjects-role:~:text=12th%20Vocational%20Subjects)
+   e) You can choose one [vocational subject](https://nios-students.pages.dev/wiki/FAQ'S#what-is-the-two-vocational-subjects-role:~:text=12th%20Vocational%20Subjects).
 
-Procedure NIOS has introduced __100% On-line__ admission in order to facilitate learners in registering themselves with it. Off-line admission quota has been dispensed with. Under this scheme learners have the options to
-- Register themselves On-line directly
-- Learners may visit their Regional Centres/Study centres for on-line registration. They aren't helpful *mostly*
-> [!TIP]
-> Though we suggest that you register yourself for admission from [NIOS SDMIMS website ](https://sdmis.nios.ac.in) it's easy!
+Procedure: NIOS has introduced __100% online__ admission to facilitate learners in registering themselves. Offline admission quotas have been dispensed with. Under this scheme, learners have the options to:
+- Register themselves online directly.
+- Visit their Regional Centres/Study Centres for online registration. (*They aren't helpful mostly.*)  
+> [!TIP]  
+> Though we suggest that you register yourself for admission from the [NIOS SDMIS website](https://sdmis.nios.ac.in), it's easy!
 
-[Link to more detailed information on Admissions](https://youtube.com/playlist?list=PLSh652xpu_YH8C93k-3hMEH5yCnIwSAyQ&si=ii9xb-BGTGF8NkX4) | [Offical Guidelines](https://drive.google.com/drive/folders/1S8z_RbST1EgllO27tPGU_uemNi7Kdpsj)
+[Link to more detailed information on Admissions](https://youtube.com/playlist?list=PLSh652xpu_YH8C93k-3hMEH5yCnIwSAyQ&si=ii9xb-BGTGF8NkX4) | [Official Guidelines](https://drive.google.com/drive/folders/1S8z_RbST1EgllO27tPGU_uemNi7Kdpsj)
 
-# Streams Of Addmission 
-In NIOS, there are __primarily four streams__. Unlike other boards you can choose whatever subjects. The stream word in the context of NIOS isn't Science,Commerce,Humanities and arts it’s on basis such as are you Pubic Exam or On Demand Exam many other factors.
+# Streams of Admission
+
+In NIOS, there are __primarily four streams__. Unlike other boards, you can choose whatever subjects you like. The term "stream" in the context of NIOS isn't Science, Commerce, Humanities, and Arts; it’s based on factors such as whether you are taking Public Exams or On-Demand Exams.
 
 <iframe width="640" height="360" src="https://www.youtube.com/embed/NpNZ-BbiLag" title="NIOS_Types_of_Admission" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 # Stream 1
-Open to all learners and freshers. Admissions are open throughout the year. Examinations are held in April-May for Block 1 learners and October-November for Block 2 learners (Although you may give exams in different blocks from yours and [On Demand](https://nios-students.pages.dev/wiki/Exams-Assignments#ode-on-demand-examination) **after the first exam is past you don't have appear in it**) Students in stream 1 must submit TMAs and attend PCP classes. [More info on TMA & PCP](Exams-Assignments) [Admission schedule Stream I](https://sdmis.nios.ac.in/home/fees#:~:text=Fee%20Structure%20%2D%20(With%20Late%20Fee)%20for%20Stream%201%20Block%20I) and [Registration folw chat](https://dq4kzxd7fbbni.cloudfront.net/static/dist/images/pdf/process-flow/ProcessFlowDetailed_SecSrSec_Stream1and2_June2023.pdf) [fees Structure](https://sdmis.nios.ac.in/home/fees#:~:text=Fee%20Structure%20%2D%20(Without%20Late%20Fee)%20for%20Stream%201%20of%20Online%20Admission)
+Open to all learners and freshers. Admissions are open throughout the year. Examinations are held in April-May for Block 1 learners and October-November for Block 2 learners. (*Although you may give exams in different blocks from yours and [On Demand](https://nios-students.pages.dev/wiki/Exams-Assignments#ode-on-demand-examination), after the first exam is past, you don't have to appear in it.*) Students in Stream 1 must submit TMAs and attend PCP classes. [More info on TMA & PCP](Exams-Assignments) | [Admission schedule Stream I](https://sdmis.nios.ac.in/home/fees#:~:text=Fee%20Structure%20%2D%20(With%20Late%20Fee)%20for%20Stream%201%20Block%20I) | [Registration flow chart](https://dq4kzxd7fbbni.cloudfront.net/static/dist/images/pdf/process-flow/ProcessFlowDetailed_SecSrSec_Stream1and2_June2023.pdf) | [Fee Structure](https://sdmis.nios.ac.in/home/fees#:~:text=Fee%20Structure%20%2D%20(Without%20Late%20Fee)%20for%20Stream%201%20of%20Online%20Admission)
 
 # Stream 2
-This stream is available for learners who have failed or passed but want to improve scores in the Secondary or Senior
-Secondary (10th class or 12th class) examination from a recognized board and want to update their qualification in one or up to four subjects to be able to fill eligibility critereas for their goals such as addmission into Commercial pilot course etc. These exams are available for to write during October-Novembber Public Examinations.
+This stream is available for learners who have failed or passed but want to improve scores in the Secondary or Senior Secondary (10th class or 12th class) examination from a recognized board and want to update their qualification in one or up to four subjects to meet eligibility criteria for their goals (e.g., admission into a commercial pilot course). These exams are available to write during October-November Public Examinations.
 
-> [!WARNING]
-> for students enrolled in Stream 2 **examination fees are included in the addmission fees for the first time**
+> [!WARNING]  
+> For students enrolled in Stream 2, **examination fees are included in the admission fees for the first time.**
 
 # Stream 3 and 4
-On-Demand Examination System (ODES) at Secondary Level (10th class) and Senior Secondary level (12th class) Open for admissions throughout the year. Suitable for learners seeking to update their qualifications or clear failed subjects. [More Info on Stream 3 & 4](https://rcguwahati.nios.ac.in/registration-for-on-demand-examination-ode-and-procedure.html)
+On-Demand Examination System (ODES) at Secondary Level (10th class) and Senior Secondary Level (12th class). Open for admissions throughout the year. Suitable for learners seeking to update their qualifications or clear failed subjects. [More Info on Stream 3 & 4](https://rcguwahati.nios.ac.in/registration-for-on-demand-examination-ode-and-procedure.html)
 
 # Transfer of Credit (ToC)
-ToC is one of the flagship features of NIOS. The **failed** learners can transfer the marks of **2** sebjects from the parent the board to NIOS.
+ToC is one of the flagship features of NIOS. **Failed** learners can transfer the marks of **2** subjects from the parent board to NIOS.
 
 **Rules and Norms of ToC:**
-- The ToC fee is ₹**230 per sebject** (as per NEW__notification:[37/2024](https://www.nios.ac.in/media/documents/notification/yr2024/Exam/Notification-34-2024.pdf)__). 
-- Subject you wish to Transfer over **must** be in NIOS's curriculum.
-- The **original failed marksheet** should be present in **physical form** and you **must** to send it your Regional Center after confirmation of admission along with a copy of your **addmission form** if you don't send it ToC won't apply.
+- The ToC fee is ₹**230 per subject** (as per NEW notification: [37/2024](https://www.nios.ac.in/media/documents/notification/yr2024/Exam/Notification-34-2024.pdf)).
+- The subject you wish to transfer over **must** be in NIOS's curriculum.
+- The **original failed marksheet** should be present in **physical form**, and you **must** send it to your Regional Center after confirmation of admission along with a copy of your **admission form**. If you don't send it, ToC won't apply.
 
-# Part or dual enrollment 
-In case a learner has already passed the Secondary(10th)/Senior Secondary (12th) or any other higher course (Diploma/Degree) he/she may opt **for upto 4 subjects** of his/her choice, to update knowledge and educational qualifications. On passing, **only the narksheet will be issued and NO other certificate will be issued** 
+# Part or Dual Enrollment
+In case a learner has already passed the Secondary (10th)/Senior Secondary (12th) or any other higher course (Diploma/Degree), he/she may opt for **up to 4 subjects** of his/her choice to update knowledge and educational qualifications. On passing, **only the marksheet will be issued, and NO other certificate will be issued.**

--- a/wiki/HandbookforS1b2.md
+++ b/wiki/HandbookforS1b2.md
@@ -1,43 +1,20 @@
-
-Still working on it. Any questions regarding this sebject please mail at unofficialnios[AT]gmail.com
+Still working on it. Any questions regarding this subject, please mail to unofficialnios[AT]gmail.com  
 -----------
+
 # Important Dates
 1. TMA uploading **June**
-2. Exam Fees payment **June**
+2. Exam fees payment **June**
 3. PCP (30 classes) **May**
-4. Last date for TMA **15 August**
+4. Last date for TMA submission **15 August**
 5. FA PCP (05 classes) **August**
 6. Results of TMA*
 7. Practical exam/SA **September (second week)** 
 8. Theory exam/PE **October-November**
-9. View assessment of SA **3 weeks from the practical exam to**
-10. Results **Dec/Jan***
-11. Re-eval/re-check **20 days after results are released**
+9. View assessment of SA **3 weeks from the practical exam**
+10. Results **December/January***
+11. Re-evaluation/re-check **20 days after results are released**
 12. Physical documents **April**
-13. Results of re-eval/re-check **May**
+13. Results of re-evaluation/re-check **May**
 
-> [!NOTE]
-> NIOS is lazy is af so, getting marks of TMAs takes time everyone gets there marks around November.
-
-
-
-Still working on it. Any questions regarding this sebject please mail at unofficialnios[AT]gmail.com
------------
-# Important Dates
-1. TMA uploading **June**
-2. Exam Fees payment **June**
-3. PCP (30 classes) **May**
-4. Last date for TMA **15 August**
-5. FA PCP (05 classes) **August**
-6. Results of TMA*
-7. Practical exam/SA **September (second week)** 
-8. Theory exam/PE **October-November**
-9. View assessment of SA **3 weeks from the practical exam to**
-10. Results **Dec/Jan***
-11. Re-eval/re-check **20 days after results are released**
-12. Physical documents **April**
-13. Results of re-eval/re-check **May**
-
-> [!NOTE]
-> NIOS is lazy is af so, getting marks of TMAs takes time everyone gets there marks around November.
-
+> [!NOTE]  
+> NIOS is lazy, so getting marks for TMAs takes time. Everyone gets their marks around November.

--- a/wiki/HandbookforS1b2.md
+++ b/wiki/HandbookforS1b2.md
@@ -19,3 +19,25 @@ Still working on it. Any questions regarding this sebject please mail at unoffic
 > [!NOTE]
 > NIOS is lazy is af so, getting marks of TMAs takes time everyone gets there marks around November.
 
+
+
+Still working on it. Any questions regarding this sebject please mail at unofficialnios[AT]gmail.com
+-----------
+# Important Dates
+1. TMA uploading **June**
+2. Exam Fees payment **June**
+3. PCP (30 classes) **May**
+4. Last date for TMA **15 August**
+5. FA PCP (05 classes) **August**
+6. Results of TMA*
+7. Practical exam/SA **September (second week)** 
+8. Theory exam/PE **October-November**
+9. View assessment of SA **3 weeks from the practical exam to**
+10. Results **Dec/Jan***
+11. Re-eval/re-check **20 days after results are released**
+12. Physical documents **April**
+13. Results of re-eval/re-check **May**
+
+> [!NOTE]
+> NIOS is lazy is af so, getting marks of TMAs takes time everyone gets there marks around November.
+

--- a/wiki/Seb_Hand_Books.md
+++ b/wiki/Seb_Hand_Books.md
@@ -5,6 +5,13 @@ title: Subject Handbooks
 
 # Specific Subject Handbooks
 
+# Specific Subject Handbooks
+
+- **[Physics-312](https://drive.google.com/file/d/1py8JKrOgukfaTjo30Q5Vjh7KZP5FBWtM/view?usp=drive_link)**  
+  *Written by Hog Rider*
+
+- **[Computer Science-330](/wiki/other-materials)**  
+  *Written by Ping*
 - **[Physics-312](https://drive.google.com/file/d/1py8JKrOgukfaTjo30Q5Vjh7KZP5FBWtM/view?usp=drive_link)**  
   *Written by Hog Rider*
 
@@ -13,5 +20,4 @@ title: Subject Handbooks
 
 - **[Guide for Stream 1 Block 1](/wiki/HandbookforS1b1)**
 
-- **[Guide for Stream 1 Block 2](/wiki/HandbookforS1b2.md)**
-  
+- **[Guide for Stream 1 Block 2](/wiki/HandbookforS1b2)**


### PR DESCRIPTION
- Improved and fixed typos in the content.
  - Corrected "mail at" to "mail to."
  - Fixed "Exam Fees payment" to "Exam fees payment."
  - Changed "there marks" to "their marks."
- Enhanced readability by:
  - Adding consistent spacing and line breaks.
  - Rephrasing sentences for better clarity (e.g., "getting marks of TMAs takes time" to "getting marks for TMAs takes time").
- Ensured no changes were made to the original meaning or structure of the content.